### PR TITLE
metarw#sn#complete: Return incomplete fakepath (without scheme) as tail_part

### DIFF
--- a/autoload/metarw/sn.vim
+++ b/autoload/metarw/sn.vim
@@ -23,7 +23,7 @@ function! metarw#sn#complete(arglead, cmdline, cursorpos)
       call add(candidate, printf('sn:%s:%s', escape(node.key, ' \/#%'), escape(s:titles[node.key], ' \/#%')))
     endif
   endfor
-  return [candidate, 'sn:', '']
+  return [candidate, 'sn:', strcharpart(a:arglead, 3)]
 endfunction
 
 function! metarw#sn#read(fakepath)


### PR DESCRIPTION
Improves behaviour with wildmode=list:longest. Without this, completion will stop at the point where the keys differ. Then when continuing to type, completion will not narrow down the results but display the same list again.

For example, if you type
```
:Ed sn:00
```
and press tab (for completion), you get
```
:Ed sn:000000
sn:00000010:Note 10  sn:00000012: Note 12
sn:00000020:Note 20  sn:00000020: Note 20
```
If you then type '1' and press tab again, you get
```
:Ed sn:0000001
sn:00000010:Note 10  sn:00000012: Note 12
sn:00000020:Note 20  sn:00000020: Note 20
```
but I would expect
```
:Ed sn:000000
sn:00000010:Note 10  sn:00000012: Note 12
```
i.e. only the matching keys should be displayed.